### PR TITLE
Print interface for ml files using dune to build the cmi

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,10 @@
+# unreleased
+
+## Added
+
+- Add support `.ml` input files as a shortcut for building the `.cmi` using dune
+  and calling `ocaml-print-intf` on the resulting file. (#1, @NathanReb)
+
 # v1.0.0 (2020-03-17)
 
 Initial public release.

--- a/README.md
+++ b/README.md
@@ -11,8 +11,10 @@ files.
 On this repository:
 
 ```
-$ dune build
-$ dune exec -- ocaml-print-intf ./_build/default/.ocaml_print_intf.eobjs/byte/dune__exe__Ocaml_print_intf.cmt
+$ dune exec -- ocaml-print-intf ocaml_print_intf.ml
+val root_from_verbose_output : string list -> string
+val target_from_verbose_output : string list -> string
+val build_cmi : string -> string
 val print_intf : string -> unit
 val version : unit -> string
 val usage : unit -> unit

--- a/dune
+++ b/dune
@@ -1,4 +1,4 @@
 (executable
   (name ocaml_print_intf)
   (public_name ocaml-print-intf)
-  (libraries compiler-libs.common dune-build-info))
+  (libraries bos compiler-libs.common dune-build-info))

--- a/ocaml_print_intf.ml
+++ b/ocaml_print_intf.ml
@@ -15,6 +15,42 @@
 
 open Format
 
+let rec root_from_verbose_output = function
+  | [] ->
+    prerr_endline
+      "Error: could not retrieve workspace root from dune build output";
+    exit 1
+  | hd::tl ->
+    match String.split_on_char ' ' (String.trim hd) with
+    | ["Workspace"; "root:"; root] -> root
+    | _ -> root_from_verbose_output tl
+
+let rec target_from_verbose_output = function
+  | [] ->
+    prerr_endline "Error: could not retrieve .cmi path from dune build output";
+    exit 1
+  | "Actual targets:"::s::_ ->
+    (* Drop the leading ["- "] *)
+    StringLabels.sub ~pos:2 ~len:(String.length s - 2) s
+  | _::tl -> target_from_verbose_output tl
+
+let build_cmi file =
+  let module_path = Fpath.(to_string (rem_ext (v file))) in
+  let target = Printf.sprintf "%%{cmi:%s}" module_path in
+  let cmd = Bos.Cmd.(v "dune" % "build" % "--verbose" % target) in
+  let result =
+    Bos.OS.Cmd.(run_out ~err:err_run_out cmd |> out_lines ~trim:true)
+  in
+  match result with
+  | Ok (output, (_, `Exited 0)) ->
+    let root = root_from_verbose_output output in
+    let target = target_from_verbose_output output in
+    Filename.concat root target
+  | Ok _ | Error _ ->
+    Printf.eprintf "Error: could not build %s's corresponding cmi using dune"
+      file;
+    exit 1
+
 let print_intf f =
   let {Cmi_format.cmi_sign;_} = Cmi_format.read_cmi f in
   Printtyp.signature std_formatter cmi_sign;
@@ -22,7 +58,7 @@ let print_intf f =
   print_newline ();
   flush stdout
 
-let version () =  
+let version () =
   match Build_info.V1.version () with
   | None -> "n/a"
   | Some v -> Build_info.V1.Version.to_string v
@@ -35,8 +71,13 @@ let () =
   match Sys.argv with
   | [| _; "--version" |] -> print_endline (version ())
   | [| _; file |] -> begin
-     try print_intf file
-     with Sys_error err -> prerr_endline err; exit 1
-        | Cmi_format.Error _ -> prerr_endline "Error: not a valid .cmi .cmt or .cmti file"; exit 1
-  end
+      match Fpath.(get_ext (v file)) with
+      | ".ml" ->
+        let cmi = build_cmi file in
+        print_intf cmi
+      | _ ->
+        try print_intf file
+        with Sys_error err -> prerr_endline err; exit 1
+           | Cmi_format.Error _ -> prerr_endline "Error: not a valid .cmi .cmt or .cmti file"; exit 1
+    end
   | _ -> usage (); exit 1


### PR DESCRIPTION
This PR allows `.ml` files to be passed to `ocaml-print-intf`. When this happens, it will try to build the corresponding `.cmi` using dune, collect its path from the verbose `dune build` command output and print it as it would for a regular `.cmi`.