### PR TITLE
Fix a bug with ml files input

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,7 +1,12 @@
+# unreleased
+
+- Fix a bug with `.ml` input files where `ocaml-print-intf` was unable to figure out
+  the dune project root if the path was too long. (#3, @NathanReb)
+
 # v1.1.0 (2020-03-26)
 
 - Add support for passing `.ml` input files as a shortcut for building the `.cmi`
-  (using dune) and calling `ocaml-print-intf` on the resulting file. (#1, @NathanReb)
+  (using dune) and calling `ocaml-print-intf` on the resulting file. (#2, @NathanReb)
 
 # v1.0.0 (2020-03-17)
 

--- a/ocaml_print_intf.ml
+++ b/ocaml_print_intf.ml
@@ -20,8 +20,9 @@ let rec root_from_verbose_output = function
     prerr_endline
       "Error: could not retrieve workspace root from dune build output";
     exit 1
+  | "Workspace root:"::root::_ -> root
   | hd::tl ->
-    match String.split_on_char ' ' (String.trim hd) with
+    match String.split_on_char ' ' hd with
     | ["Workspace"; "root:"; root] -> root
     | _ -> root_from_verbose_output tl
 


### PR DESCRIPTION
`ocaml-print-intf` uses dune verbose logs from the output to determine the target and the workspace root to be able to get a reliable path to the wanted `.cmi`.

The log line with the workspace root will span on two lines instead of one if the path is too long and it used to cause a hard failure when it did. This PR fixes that!